### PR TITLE
Implement forum-user-auth for WI

### DIFF
--- a/app/Http/Controllers/Auth/ServerController.php
+++ b/app/Http/Controllers/Auth/ServerController.php
@@ -87,19 +87,18 @@ class ServerController extends Controller
         }
 
         $client_token = $request->session()->pull('server_client_token');
+        $byond_key_is_linked = $request->user()->byond_key != null;
 
-        if ($request->user()->byond_key == null) {
-            Log::debug("server.login - Unable to Auth - User has no ckey linked");
-            return view('auth.server.nokey');
-        }
         $query = new ServerQuery;
         try {
-            Log::debug("server.login - Sending auth_client request to server for ckey: " . $request->user()->byond_key);
+            Log::debug("server.login - Sending auth_client request to server for ckey and forum account: " . $request->user()->byond_key . ", " . $request->user()->name);
             $query->setUp(config('aurora.gameserver_address'), config('aurora.gameserver_port'), config('aurora.gameserver_auth'));
             $query->runQuery([
                 'query' => 'auth_client',
                 'clienttoken' => $client_token,
-                'key' => $request->user()->byond_key
+                'key' => $request->user()->byond_key,
+                'forumuser' => $request->user()->name,
+                'use-external-key' =>  $byond_key_is_linked
             ]);
         } catch (\Exception $e) {
             Log::debug("server.login - Error while sending auth_client request to server: " . $e->getMessage());
@@ -107,7 +106,7 @@ class ServerController extends Controller
         }
 
         if ($query->response->statuscode == '200') {
-            Log::debug("server.login - Ckey Succesfully logged in: " . $request->user()->byond_key);
+            Log::debug("server.login - Ckey or external user succesfully logged in: " . $request->user()->byond_key . ", " . $request->user()->name);
             return view('auth.server.success');
         } else {
             Log::debug("server.login - Invalid status-code while sending auth_client request to server: " . $query->response->statuscode);

--- a/app/Http/Controllers/Auth/ServerController.php
+++ b/app/Http/Controllers/Auth/ServerController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 
 use App\Models\User;
 use App\Services\Server\ServerQuery;
+use App\Services\Server\Helpers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -89,6 +90,13 @@ class ServerController extends Controller
         $client_token = $request->session()->pull('server_client_token');
         $byond_key_is_linked = $request->user()->byond_key != null;
 
+        $ckey_is_external = False;
+        if ($byond_key_is_linked) {
+            $ckey_is_external = ServerPlayer::where('ckey', $request->user()->byond_key)->select('ckey_is_external')->firstOrFail();
+        } else {
+            $ckey_is_external = True;
+        }
+
         $query = new ServerQuery;
         try {
             Log::debug("server.login - Sending auth_client request to server for ckey and forum account: " . $request->user()->byond_key . ", " . $request->user()->name);
@@ -98,7 +106,7 @@ class ServerController extends Controller
                 'clienttoken' => $client_token,
                 'key' => $request->user()->byond_key,
                 'forumuser' => $request->user()->name,
-                'use-external-key' =>  $byond_key_is_linked
+                'use-external-key' => $ckey_is_external
             ]);
         } catch (\Exception $e) {
             Log::debug("server.login - Error while sending auth_client request to server: " . $e->getMessage());
@@ -107,6 +115,13 @@ class ServerController extends Controller
 
         if ($query->response->statuscode == '200') {
             Log::debug("server.login - Ckey or external user succesfully logged in: " . $request->user()->byond_key . ", " . $request->user()->name);
+
+            // User was authorized but no BYOND key is linked yet. Ergo, external ckey was used. Link it.
+            if ($byond_key_is_linked == False) {
+                $fake_ckey = "GuestF-" . Helpers::sanitize_ckey($request->user()->name);
+                $request->user()->linkWithCkey($fake_ckey);
+            }
+
             return view('auth.server.success');
         } else {
             Log::debug("server.login - Invalid status-code while sending auth_client request to server: " . $query->response->statuscode);

--- a/app/Http/Controllers/User/LinkController.php
+++ b/app/Http/Controllers/User/LinkController.php
@@ -49,20 +49,8 @@ class LinkController extends Controller
             //Check if the linking request is set to something other than new
             if ($linking_request->status == "confirmed") {
                 //If its confirmed write it to the forum db
-                $sanitized_key = Helpers::sanitize_ckey($linking_request->player_ckey);
-                $request->user()->byond_key = $sanitized_key;
-                $request->user()->save();
 
-                //Update the forum
-                $base_url = config('aurora.forum_url');
-                if ($base_url) {
-                    $request_url = $base_url . 'api/core/members/' . $request->user()->id .
-                        '?key=' . config('aurora.forum_api_key') .
-                        '&customFields[' . config('aurora.forum_byond_attribute') . ']=' . $sanitized_key;
-                    $client = new \GuzzleHttp\Client();
-                    $client->request('POST', $request_url);
-                }
-
+                $request->user()->linkWithCkey($byond_key);
 
                 //Set the status of the linking request to linked and set the deleted_at date
                 DB::connection('server')->table('player_linking')

--- a/app/Http/Controllers/User/LinkController.php
+++ b/app/Http/Controllers/User/LinkController.php
@@ -118,11 +118,15 @@ class LinkController extends Controller
 
         $ckey = Helpers::sanitize_ckey($request->input("Byond_Username"));
 
-        #Check if a player with that ckey exists
-        $player_count = ServerPlayer::where('ckey', $ckey)->count();
+        $player = ServerPlayer::where('ckey', $ckey)->first();
 
-        if ($player_count != 1) {
+        #Check if a player with that ckey exists
+        if (is_null($player)) {
             return redirect()->route('user.link')->withErrors(array("Could not find player with the ckey" . $ckey . ". You need to join on the server before you can link your account."));
+        }
+
+        if ($player->ckey_is_external) {
+            return redirect()->route('user.link')->withErrors(array("Your ckey " . $ckey . " is an external ckey. Linking forum accounts to these keys is currently not supported."));
         }
 
         //Only add a new linking request if there is no existing one (where the deleted_at date is not set)

--- a/app/Models/ServerPlayer.php
+++ b/app/Models/ServerPlayer.php
@@ -28,7 +28,7 @@ class ServerPlayer extends Model
     public $timestamps = FALSE;
     protected $connection = 'server';
     protected $table = 'player';
-    protected $fillable = ['ckey', 'ip', 'whitelist_status'];
+    protected $fillable = ['ckey', 'ip', 'whitelist_status', 'ckey_is_external'];
     protected $primaryKey = 'id';
     protected $dates = ['firstseen', 'lastseen'];
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use App\Models\ServerPlayer;
 use App\Models\SiteRole;
+use App\Services\Server\Helpers;
 
 class User extends Authenticatable
 {
@@ -147,6 +148,35 @@ class User extends Authenticatable
                 return FALSE;
         } else {
             return NULL;
+        }
+    }
+
+    /**
+     * Linked the user account to a specified ckey. Will also create the link in the forums.
+     * 
+     * Will throw if the user is already linked with a byond key.
+     * 
+     * @param $byond_key
+     */
+    public function linkWithCkey($byond_key)
+    {
+        if ($this->byond_linked == True) {
+            throw new \Exception("User already linked with a ckey.");
+        }
+
+        $sanitized_key = Helpers::sanitize_ckey($byond_key);
+        $this->byond_key = $sanitized_key;
+        $this->byond_linked = True;
+        $this->save();
+
+        //Update the forum
+        $base_url = config('aurora.forum_url');
+        if ($base_url) {
+            $request_url = $base_url . 'api/core/members/' . $this->id .
+                '?key=' . config('aurora.forum_api_key') .
+                '&customFields[' . config('aurora.forum_byond_attribute') . ']=' . $sanitized_key;
+            $client = new \GuzzleHttp\Client();
+            $client->request('POST', $request_url);
         }
     }
 }


### PR DESCRIPTION
NB: This requires a change that's WIP in the game server code.

We allow users to authenticate with the game server using their forum account even if they don't have a linked ckey. All of the ckey composition will be done by the game server. The WI will now simply forward the authentication request to the server, with extra information in tow.

New query for auth_client:
```php
                'query' => 'auth_client',
                'clienttoken' => $client_token,
                'key' => $request->user()->byond_key, // can now be null.
                'forumuser' => $request->user()->name, // the forum username, the game server will use this to generate a consistent ckey if key is null.
                'use-external-key' =>  $byond_key_is_linked // bool to indicate whether a ckey is linked or not.
```

Consideration: first time use of this should also link the fake ckey to the user's forum account. Should this be done in the WI side code or in the game side code? Can it even be done in the game side code?